### PR TITLE
✏️ Fix postman typos

### DIFF
--- a/postman.json
+++ b/postman.json
@@ -24,7 +24,7 @@
 							}
 						},
 						"url": {
-							"raw": "{{url}}auth/login",
+							"raw": "{{url}}/auth/login",
 							"host": [
 								"{{url}}auth"
 							],

--- a/postman.json
+++ b/postman.json
@@ -131,7 +131,7 @@
 							}
 						},
 						"url": {
-							"raw": "https://fake-trello-api.herokuapp.com/api/v1/auth/change-password",
+							"raw": "{{url}}/auth/change-password",
 							"protocol": "https",
 							"host": [
 								"fake-trello-api",


### PR DESCRIPTION
¡Hola otra vez @nicobytes!

Cometí un error al escribir la URL de la petición de _Login_, ya que la variable `url` en Postman no termina con un slash, y en la URL de la petición aparece como `{{url}}auth/login`. Por ende, la cambié a `{{url}}/auth/login`.

Igualmente, en la petición de _Change Password_, coloqué la URL quemada en vez de la variable.